### PR TITLE
duckdb: IndexReport, transactional index creation, tests

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -14,6 +14,11 @@ allowed-duplicate-crates = [
   "windows-link",
   "thiserror",
   "thiserror-impl",
+  "getrandom",
+  "hashbrown",
+  "syn",
+  "wasi",
+  "ahash",
 ]
 
 # 可选：对部分规则进行强制

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,37 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "getrandom 0.3.3",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,10 +70,189 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "arrow"
+version = "56.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c26b57282a08ae92f727497805122fec964c6245cfa0e13f0e75452eaf3bc41f"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "56.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cebf38ca279120ff522f4954b81a39527425b6e9f615e6b72842f4de1ffe02b8"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "num",
+]
+
+[[package]]
+name = "arrow-array"
+version = "56.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744109142cdf8e7b02795e240e20756c2a782ac9180d4992802954a8f871c0de"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.15.5",
+ "num",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "56.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601bb103c4c374bcd1f62c66bcea67b42a2ee91a690486c37d4c180236f11ccc"
+dependencies = [
+ "bytes",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "56.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed61d9d73eda8df9e3014843def37af3050b5080a9acbe108f045a316d5a0be"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64",
+ "chrono",
+ "comfy-table",
+ "half",
+ "lexical-core",
+ "num",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-data"
+version = "56.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43407f2c6ba2367f64d85d4603d6fb9c4b92ed79d2ffd21021b37efa96523e12"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "56.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c142a147dceb59d057bad82400f1693847c80dca870d008bf7b91caf902810ae"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+]
+
+[[package]]
+name = "arrow-row"
+version = "56.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac6620667fccdab4204689ca173bd84a15de6bb6b756c3a8764d4d7d0c2fc04"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "56.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa93af9ff2bb80de539e6eb2c1c8764abd0f4b73ffb0d7c82bf1f9868785e66"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "arrow-select"
+version = "56.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8b2e0052cd20d36d64f32640b68a5ab54d805d24a473baee5d52017c85536c"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num",
+]
+
+[[package]]
+name = "arrow-string"
+version = "56.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2155e26e17f053c8975c546fc70cf19c00542f9abf43c23a88a46ef7204204f"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -51,10 +261,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "borsh"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
+dependencies = [
+ "borsh-derive",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cast"
@@ -69,6 +342,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -77,6 +352,12 @@ name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -88,7 +369,7 @@ dependencies = [
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -144,10 +425,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "comfy-table"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03b7db8e0b4b2fdad6c551e634134e99ec000e5c8c3b6856c65e8bbaded7a3b"
+dependencies = [
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "criterion"
@@ -232,10 +552,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "duckdb"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2207e2cc81719eca29ef65cf904df49505cb0346c460ba6272c99cc5d7eb655"
+dependencies = [
+ "arrow",
+ "cast",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libduckdb-sys",
+ "num-integer",
+ "rust_decimal",
+ "strum",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -248,16 +591,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "filetime"
+version = "0.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
+
+[[package]]
+name = "flate2"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
 
 [[package]]
 name = "getrandom"
@@ -268,7 +668,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi",
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -279,7 +679,47 @@ checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "iana-time-zone"
@@ -306,6 +746,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.0",
+]
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +769,16 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -337,10 +797,106 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lexical-core"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b765c31809609075565a70b4b71402281283aeda7ecaf4818ac14a7b2ade8958"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de6f9cb01fb0b08060209a057c048fcbab8717b4c1ecd2eac66ebfe39a65b0f2"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72207aae22fc0a121ba7b6d479e42cbfea549af1479c3f3a4f12c70dd66df12e"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a82e24bf537fd24c177ffbbdc6ebcc8d54732c35b50a3f28cc3f4e4c949a0b3"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5afc668a27f460fb45a81a757b6bf2f43c2d7e30cb5a2dcd3abf294c78d62bd"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629ddff1a914a836fb245616a7888b62903aae58fa771e1d83943035efa0f978"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "libduckdb-sys"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d70696fa43ca9ed04ab7d8bfd4f3f1df73cabd3c872d67ddc9f55bb8dd4d1a"
+dependencies = [
+ "cc",
+ "flate2",
+ "pkg-config",
+ "serde",
+ "serde_json",
+ "tar",
+ "vcpkg",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "libredox"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+dependencies = [
+ "bitflags",
+ "libc",
+ "redox_syscall",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -370,6 +926,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,10 +944,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -391,6 +1020,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -410,6 +1040,12 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plotters"
@@ -446,12 +1082,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -468,6 +1142,42 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
+]
 
 [[package]]
 name = "rayon"
@@ -487,6 +1197,15 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -517,6 +1236,60 @@ name = "regex-syntax"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+
+[[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.7.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8975fc98059f365204d635119cf9c5a60ae67b841ed49b5422a9a7e56cdfac0"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand",
+ "rkyv",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "rustix"
@@ -553,6 +1326,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
 name = "serde"
 version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,7 +1358,7 @@ checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -611,6 +1390,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,6 +1408,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "criterion",
+ "duckdb",
  "lazy_static",
  "log",
  "memchr",
@@ -632,6 +1418,44 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -646,13 +1470,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.0",
@@ -684,7 +1525,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -695,7 +1536,7 @@ checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -739,6 +1580,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,6 +1596,51 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f1085dec27c2b6632b04c80b3bb1b4300d6495d1e129693bdda7d91e72eec1"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3effe7c0e86fdff4f69cdd2ccc1b96f933e24811c5441d44904e8683e27184b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -779,7 +1674,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -828,10 +1723,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+
+[[package]]
+name = "uuid"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -842,6 +1771,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -884,7 +1819,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
@@ -906,7 +1841,7 @@ checksum = "ffc003a991398a8ee604a401e194b6b3a39677b3173d6e74495eb51b82e99a32"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -947,7 +1882,7 @@ checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.2.0",
  "windows-result",
  "windows-strings",
 ]
@@ -960,7 +1895,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -971,8 +1906,14 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-link"
@@ -986,7 +1927,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -995,7 +1936,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -1004,7 +1945,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -1013,7 +1963,7 @@ version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -1022,14 +1972,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -1039,10 +2006,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1051,10 +2030,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1063,10 +2054,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1075,13 +2078,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
+name = "xattr"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 tracing-appender = "0.2"
 # flexi_logger removed in favor of env_logger to reduce transitive windows-* versions
 chrono = "0.4"
+duckdb = { version = "1.4.0", features = ["bundled"] }
 
 [dev-dependencies]
 criterion = "0.7"

--- a/README.md
+++ b/README.md
@@ -58,3 +58,97 @@ Sep 20 12:35:03 ERROR sqllog_analysis: 读取文件 failed.log: IO错误: No suc
 - 消息：具体日志内容，可能包括解析统计、错误信息或调试提示。
 
 这些行同时会写入默认的日志文件 `logs/sqllog-analysis-YYYY-MM-DD.log`，便于长期保存和分析。
+
+## DuckDB 写入器 (duckdb_writer)
+
+本仓库提供了一个将解析后的 `Sqllog` 记录直接写入 DuckDB 的写入器，使用 DuckDB 的 Appender API 批量插入以提高性能。
+
+主要 API（位于 crate 根的 `duckdb_writer` 模块）：
+
+- `write_sqllogs_to_duckdb<P: AsRef<Path>>(db_path: P, records: &[Sqllog]) -> Result<()>`：默认使用 chunk 大小 1000，依据环境变量决定是否创建索引。
+- `write_sqllogs_to_duckdb_with_chunk<P: AsRef<Path>>(db_path: P, records: &[Sqllog], chunk_size: usize) -> Result<()>`：手动指定 chunk 大小（`0` 会被归一为 `1`）。
+- `write_sqllogs_to_duckdb_with_chunk_and_report<P: AsRef<Path>>(db_path: P, records: &[Sqllog], chunk_size: usize, create_indexes: bool) -> Result<Vec<IndexReport>>`：显式控制是否创建索引，并返回每个索引创建的 `IndexReport` 列表。
+
+IndexReport 结构体字段：
+
+- `statement: String`：执行的 CREATE INDEX 语句。
+- `elapsed_ms: Option<u128>`：创建成功时的耗时（毫秒）。失败时为 `None`。
+- `error: Option<String>`：若创建失败，此处包含错误字符串；成功时为 `None`。
+
+索引与日志控制的环境变量：
+
+- `SQLOG_CREATE_INDEXES`：是否在写入后创建索引。默认开启（未设置或非 "0" 时为 true）。将其设置为 `0` 则跳过索引创建。
+- `SQLOG_INDEX_LOG_LEVEL`：索引创建期间的日志级别。默认 `info`；设置为 `debug` 将使用 `debug!` 打印更详细的索引创建信息。
+
+示例（PowerShell）：
+
+```powershell
+# 在 /tmp/my.duckdb 写入，并显式创建索引，chunk=500
+.
+# 运行示例（伪代码）
+# 调用 Rust API： duckdb_writer::write_sqllogs_to_duckdb_with_chunk_and_report("/tmp/my.duckdb", &records, 500, true)
+
+# 在环境中开启 debug 日志用于索引创建
+$env:SQLOG_INDEX_LOG_LEVEL = "debug"
+
+# 或者禁止索引创建
+$env:SQLOG_CREATE_INDEXES = "0"
+```
+
+注意：索引通常会在批量插入之后创建以获得更好的插入性能。若你希望索引创建失败能回滚整个批次，或者希望把索引创建改为一次性原子操作，可以在调用处实现更高层的事务控制或修改写入器行为（当前实现为每个索引独立短事务，并在 `IndexReport` 中报告失败）。
+
+示例（Rust 代码片段）：
+
+```rust
+use sqllog_analysis::duckdb_writer;
+use sqllog_analysis::sqllog::Sqllog;
+
+fn write_and_report(db_path: &str, records: &[Sqllog]) -> anyhow::Result<()> {
+		// chunk_size = 500, create indexes = true
+		let reports = duckdb_writer::write_sqllogs_to_duckdb_with_chunk_and_report(db_path, records, 500, true)?;
+
+		for r in reports {
+				match r.error {
+						Some(err) => eprintln!("index '{}' failed: {}", r.statement, err),
+						None => println!("index '{}' created in {:?} ms", r.statement, r.elapsed_ms),
+				}
+		}
+
+		Ok(())
+}
+```
+
+CI 运行（GitHub Actions）：如果你想在 CI 中也执行“失败路径”测试，可以在 workflow 中设置环境变量：
+
+```yaml
+name: Rust
+
+on: [push, pull_request]
+
+jobs:
+	test:
+		runs-on: ubuntu-latest
+		steps:
+			- uses: actions/checkout@v4
+			- name: Install Rust
+				uses: dtolnay/rust-toolchain@v1
+			- name: Run tests
+				run: |
+					cargo test --all -- --nocapture
+
+	# Separate job to exercise the injected bad-index test so it doesn't
+	# interfere with normal test runs or environment expectations.
+	index-failure-test:
+		runs-on: ubuntu-latest
+		steps:
+			- uses: actions/checkout@v4
+			- name: Install Rust
+				uses: dtolnay/rust-toolchain@v1
+			- name: Run injected-index test
+				env:
+					SQLOG_INJECT_BAD_INDEX: "1"
+					SQLOG_CREATE_INDEXES: "1"
+				run: |
+					cargo test --test duckdb_index_failure -- --nocapture
+
+```

--- a/benches/datetime_benchmark.rs
+++ b/benches/datetime_benchmark.rs
@@ -1,6 +1,7 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use regex::Regex;
 use sqllog_analysis::sqllog::is_first_row;
+use std::hint;
 
 fn validate_with_regex(s: &str) -> bool {
     // 编译正则表达式
@@ -25,32 +26,32 @@ fn datetime_benchmark(c: &mut Criterion) {
 
     // 测试自定义实现 - 有效日期
     group.bench_function("custom_valid", |b| {
-        b.iter(|| is_first_row(std::hint::black_box(valid_date)))
+        b.iter(|| is_first_row(hint::black_box(valid_date)))
     });
 
     // 测试自定义实现 - 无效日期
     group.bench_function("custom_invalid", |b| {
-        b.iter(|| is_first_row(std::hint::black_box(invalid_date)))
+        b.iter(|| is_first_row(hint::black_box(invalid_date)))
     });
 
     // 测试正则表达式实现 - 有效日期
     group.bench_function("regex_valid", |b| {
-        b.iter(|| validate_with_regex(std::hint::black_box(valid_date)))
+        b.iter(|| validate_with_regex(hint::black_box(valid_date)))
     });
 
     // 测试正则表达式实现 - 无效日期
     group.bench_function("regex_invalid", |b| {
-        b.iter(|| validate_with_regex(std::hint::black_box(invalid_date)))
+        b.iter(|| validate_with_regex(hint::black_box(invalid_date)))
     });
 
     // 测试 chrono 实现 - 有效日期
     group.bench_function("chrono_valid", |b| {
-        b.iter(|| validate_with_chrono(std::hint::black_box(valid_date)))
+        b.iter(|| validate_with_chrono(hint::black_box(valid_date)))
     });
 
     // 测试 chrono 实现 - 无效日期
     group.bench_function("chrono_invalid", |b| {
-        b.iter(|| validate_with_chrono(std::hint::black_box(invalid_date)))
+        b.iter(|| validate_with_chrono(hint::black_box(invalid_date)))
     });
 
     group.finish();

--- a/benches/sqllog_benchmark.rs
+++ b/benches/sqllog_benchmark.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::uninlined_format_args)]
 use criterion::{Criterion, criterion_group, criterion_main};
-use std::io::Write;
+use sqllog_analysis::sqllog::Sqllog;
+use std::{fs::File, io::Write};
 
 fn bench_sqllog_from_file_1m(c: &mut Criterion) {
     // 构造 100 万条日志，每条 description 多行
@@ -13,11 +14,11 @@ fn bench_sqllog_from_file_1m(c: &mut Criterion) {
     }
     let dir = tempfile::tempdir().unwrap();
     let file_path = dir.path().join("bench_1m.log");
-    let mut file = std::fs::File::create(&file_path).unwrap();
+    let mut file = File::create(&file_path).unwrap();
     file.write_all(log_content.as_bytes()).unwrap();
     c.bench_function("sqllog_from_file_1m", |b| {
         b.iter(|| {
-            let (logs, errors) = sqllog_analysis::sqllog::Sqllog::from_file_with_errors(&file_path);
+            let (logs, errors) = Sqllog::from_file_with_errors(&file_path);
             assert_eq!(logs.len(), 1_000_000);
             assert!(errors.is_empty());
         })

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,10 @@
+use std::env;
+
+fn main() {
+    // Only add this system library on Windows targets. DuckDB's bundled
+    // library may reference Restart Manager (Rm*) symbols which are
+    // provided by Rstrtmgr.lib on Windows. Instruct rustc to link it.
+    if env::var("CARGO_CFG_TARGET_OS").unwrap_or_default() == "windows" {
+        println!("cargo:rustc-link-lib=Rstrtmgr");
+    }
+}

--- a/src/duckdb_writer.rs
+++ b/src/duckdb_writer.rs
@@ -1,0 +1,299 @@
+use crate::sqllog::Sqllog;
+use anyhow::{Context, Result};
+use duckdb::{Connection, ToSql, appender_params_from_iter, params};
+use log::{debug, info, warn};
+use std::env;
+use std::path::Path;
+use std::time::Instant;
+
+// Type alias placed at module level to avoid declaring items after statements
+// (clippy::items_after_statements). This alias represents one row prepared for
+// the DuckDB appender and reduces visual type complexity in the function body.
+type AppenderRow = (
+    String,
+    i32,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    String,
+    Option<i64>,
+    Option<i64>,
+    Option<i64>,
+);
+
+// No helper needed: `Sqllog` stores i64 fields now.
+
+/// Default entry: uses chunk size `1000`.
+///
+/// # Errors
+/// Returns an error if opening the database, creating the table, or writing fails.
+pub fn write_sqllogs_to_duckdb<P: AsRef<Path>>(db_path: P, records: &[Sqllog]) -> Result<()> {
+    // default behavior: use chunk 1000, env var controls index creation
+    write_sqllogs_to_duckdb_impl(db_path, records, 1000, None).map(|_| ())
+}
+
+/// Write records into `DuckDB` using the Appender API with configurable `chunk_size`.
+/// `chunk_size == 0` is normalized to `1`.
+///
+/// # Errors
+/// Returns an error if opening the database, creating the table, or writing fails.
+#[allow(clippy::too_many_lines)]
+pub fn write_sqllogs_to_duckdb_with_chunk<P: AsRef<Path>>(
+    db_path: P,
+    records: &[Sqllog],
+    chunk_size: usize,
+) -> Result<()> {
+    // default: honor environment variable if set
+    write_sqllogs_to_duckdb_impl(db_path, records, chunk_size, None).map(|_| ())
+}
+
+/// Public API to explicitly control whether indexes are created after writing.
+/// Returns a Vec of (`index_statement`, `elapsed_ms`) for created indexes.
+/// # Errors
+/// Returns an error if opening the database, creating the table, appender usage,
+/// or index creation fails.
+/// Reports the result of attempting to create an index.
+#[derive(Debug)]
+pub struct IndexReport {
+    /// The CREATE INDEX statement executed.
+    pub statement: String,
+    /// Elapsed time in milliseconds when the statement succeeded.
+    pub elapsed_ms: Option<u128>,
+    /// If creation failed, this contains the error string.
+    pub error: Option<String>,
+}
+
+/// Public API to explicitly control whether indexes are created after writing.
+/// Returns a Vec of `IndexReport` describing success/failure for each attempted index.
+/// # Errors
+/// Returns an error if opening the database, creating the table, or appender usage fails.
+pub fn write_sqllogs_to_duckdb_with_chunk_and_report<P: AsRef<Path>>(
+    db_path: P,
+    records: &[Sqllog],
+    chunk_size: usize,
+    create_indexes: bool,
+) -> Result<Vec<IndexReport>> {
+    Ok(
+        write_sqllogs_to_duckdb_impl(db_path, records, chunk_size, Some(create_indexes))?
+            .unwrap_or_default(),
+    )
+}
+
+// Core implementation shared by public wrappers. If `create_indexes_override` is
+// Some(true/false) it overrides the environment variable; if None the env var
+// SQLOG_CREATE_INDEXES determines behavior (default true).
+#[allow(clippy::too_many_lines)]
+fn write_sqllogs_to_duckdb_impl<P: AsRef<Path>>(
+    db_path: P,
+    records: &[Sqllog],
+    chunk_size: usize,
+    create_indexes_override: Option<bool>,
+) -> Result<Option<Vec<IndexReport>>> {
+    let mut conn = Connection::open(db_path.as_ref()).with_context(|| {
+        format!(
+            "failed to open duckdb database {}",
+            db_path.as_ref().display()
+        )
+    })?;
+
+    let create_sql = r"CREATE TABLE IF NOT EXISTS sqllogs (
+        occurrence_time TEXT NOT NULL,
+        ep INTEGER NOT NULL,
+        session TEXT,
+        thread TEXT,
+        user TEXT,
+        trx_id TEXT,
+        statement TEXT,
+        appname TEXT,
+        ip TEXT,
+        sql_type TEXT,
+        description TEXT NOT NULL,
+        execute_time BIGINT,
+        rowcount BIGINT,
+        execute_id BIGINT
+    )";
+
+    conn.execute(create_sql, params![])?;
+
+    let tx = conn.transaction()?;
+    let mut app = tx.appender("sqllogs")?;
+
+    let chunk_size = if chunk_size == 0 { 1 } else { chunk_size };
+
+    let mut chunk_owned: Vec<AppenderRow> = Vec::with_capacity(chunk_size);
+
+    for r in records {
+        let execute_time_i = r.execute_time;
+        let rowcount_i = r.rowcount;
+        let execute_id_i = r.execute_id;
+
+        chunk_owned.push((
+            r.occurrence_time.clone(),
+            r.ep,
+            r.session.clone(),
+            r.thread.clone(),
+            r.user.clone(),
+            r.trx_id.clone(),
+            r.statement.clone(),
+            r.appname.clone(),
+            r.ip.clone(),
+            r.sql_type.clone(),
+            r.description.clone(),
+            execute_time_i,
+            rowcount_i,
+            execute_id_i,
+        ));
+
+        if chunk_owned.len() >= chunk_size {
+            let drained = std::mem::take(&mut chunk_owned);
+            let rows = drained.into_iter().map(|t| {
+                appender_params_from_iter(vec![
+                    Box::new(t.0) as Box<dyn ToSql>,
+                    Box::new(t.1) as Box<dyn ToSql>,
+                    Box::new(t.2) as Box<dyn ToSql>,
+                    Box::new(t.3) as Box<dyn ToSql>,
+                    Box::new(t.4) as Box<dyn ToSql>,
+                    Box::new(t.5) as Box<dyn ToSql>,
+                    Box::new(t.6) as Box<dyn ToSql>,
+                    Box::new(t.7) as Box<dyn ToSql>,
+                    Box::new(t.8) as Box<dyn ToSql>,
+                    Box::new(t.9) as Box<dyn ToSql>,
+                    Box::new(t.10) as Box<dyn ToSql>,
+                    Box::new(t.11) as Box<dyn ToSql>,
+                    Box::new(t.12) as Box<dyn ToSql>,
+                    Box::new(t.13) as Box<dyn ToSql>,
+                ])
+            });
+
+            app.append_rows(rows)?;
+            app.flush()?;
+            chunk_owned = Vec::with_capacity(chunk_size);
+        }
+    }
+
+    if !chunk_owned.is_empty() {
+        let drained = std::mem::take(&mut chunk_owned);
+        let rows = drained.into_iter().map(|t| {
+            appender_params_from_iter(vec![
+                Box::new(t.0) as Box<dyn ToSql>,
+                Box::new(t.1) as Box<dyn ToSql>,
+                Box::new(t.2) as Box<dyn ToSql>,
+                Box::new(t.3) as Box<dyn ToSql>,
+                Box::new(t.4) as Box<dyn ToSql>,
+                Box::new(t.5) as Box<dyn ToSql>,
+                Box::new(t.6) as Box<dyn ToSql>,
+                Box::new(t.7) as Box<dyn ToSql>,
+                Box::new(t.8) as Box<dyn ToSql>,
+                Box::new(t.9) as Box<dyn ToSql>,
+                Box::new(t.10) as Box<dyn ToSql>,
+                Box::new(t.11) as Box<dyn ToSql>,
+                Box::new(t.12) as Box<dyn ToSql>,
+                Box::new(t.13) as Box<dyn ToSql>,
+            ])
+        });
+
+        app.append_rows(rows)?;
+        app.flush()?;
+    }
+
+    drop(app);
+    tx.commit()?;
+
+    // Create indexes after bulk insert to speed up subsequent queries.
+    // Use IF NOT EXISTS to make this idempotent. We run each index creation in
+    // its own short-lived transaction so a failing index creation doesn't leave
+    // the database in a partial state and so we can capture per-index errors.
+    // build the list of index statements; allow test injection of a bad
+    // statement via SQLOG_INJECT_BAD_INDEX to exercise failure handling.
+    let mut index_statements: Vec<String> = vec![
+        "CREATE INDEX IF NOT EXISTS idx_sqllogs_trx_id ON sqllogs(trx_id)".to_string(),
+        "CREATE INDEX IF NOT EXISTS idx_sqllogs_thread ON sqllogs(thread)".to_string(),
+        "CREATE INDEX IF NOT EXISTS idx_sqllogs_session ON sqllogs(session)".to_string(),
+        "CREATE INDEX IF NOT EXISTS idx_sqllogs_ip ON sqllogs(ip)".to_string(),
+    ];
+
+    if env::var("SQLOG_INJECT_BAD_INDEX").is_ok() {
+        // inject a statement that should fail (nonexistent column) to test
+        // error reporting. Tests can set SQLOG_INJECT_BAD_INDEX=1 temporarily.
+        index_statements
+            .push("CREATE INDEX idx_sqllogs_bad ON sqllogs(nonexistent_column)".to_string());
+    }
+
+    // decide whether to create indexes:
+    let create_indexes = create_indexes_override.map_or_else(
+        || {
+            env::var("SQLOG_CREATE_INDEXES")
+                .map(|v| v != "0")
+                .unwrap_or(true)
+        },
+        |b| b,
+    );
+
+    if !create_indexes {
+        info!("SQLOG_CREATE_INDEXES=0 -> skipping index creation");
+        return Ok(None);
+    }
+
+    // log level for index creation messages (info or debug). Default: info.
+    let index_log_level = env::var("SQLOG_INDEX_LOG_LEVEL").unwrap_or_else(|_| "info".into());
+    let use_debug = index_log_level.eq_ignore_ascii_case("debug");
+
+    let mut reports: Vec<IndexReport> = Vec::with_capacity(index_statements.len());
+    for stmt in index_statements {
+        if use_debug {
+            debug!("creating index: {stmt}");
+        } else {
+            info!("creating index: {stmt}");
+        }
+
+        // each index in its own transaction
+        let start = Instant::now();
+        let idx_result = (|| -> Result<Option<u128>> {
+            let tx = conn.transaction()?;
+            // executing within this transaction; stmt is owned String so pass &str
+            tx.execute(stmt.as_str(), params![])?;
+            tx.commit()?;
+            Ok(Some(start.elapsed().as_millis()))
+        })();
+
+        match idx_result {
+            Ok(Some(ms)) => {
+                if use_debug {
+                    debug!("created index: {stmt} in {ms} ms");
+                } else {
+                    info!("created index: {stmt} in {ms} ms");
+                }
+                reports.push(IndexReport {
+                    statement: stmt.clone(),
+                    elapsed_ms: Some(ms),
+                    error: None,
+                });
+            }
+            Ok(None) => {
+                // unexpected empty result
+                warn!("index creation returned no timing for: {stmt}");
+                reports.push(IndexReport {
+                    statement: stmt.clone(),
+                    elapsed_ms: None,
+                    error: None,
+                });
+            }
+            Err(e) => {
+                let err = format!("{e}");
+                warn!("failed to create index: {stmt} -> {err}");
+                reports.push(IndexReport {
+                    statement: stmt.clone(),
+                    elapsed_ms: None,
+                    error: Some(err),
+                });
+            }
+        }
+    }
+
+    Ok(Some(reports))
+}

--- a/src/input_path.rs
+++ b/src/input_path.rs
@@ -1,7 +1,9 @@
 use log::{info, trace};
-use std::env;
-use std::io::{self, Write};
-use std::path::PathBuf;
+use std::{
+    env,
+    io::{self, Write},
+    path::PathBuf,
+};
 
 /// 获取 sqllog 文件夹路径，优先命令行参数，否则交互输入。
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::multiple_crate_versions)]
 
+pub mod duckdb_writer;
 pub mod input_path;
 pub mod process;
 pub mod sqllog;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,20 +1,24 @@
 mod analysis_log;
+
 use analysis_log::LogConfig;
 use anyhow::Result;
 use log::{error, info, trace};
-use sqllog_analysis::input_path::get_sqllog_dir;
-use sqllog_analysis::process::{process_sqllog_dir, write_error_files};
+use sqllog_analysis::{
+    input_path::get_sqllog_dir,
+    process::{process_sqllog_dir, write_error_files},
+};
+use std::env;
 
 fn main() -> Result<()> {
     // 日志参数解析与初始化
-    let log_config = LogConfig::from_args(std::env::args().skip(1));
+    let log_config = LogConfig::from_args(env::args().skip(1));
     log_config.init();
 
     trace!("开始获取 sqllog 目录");
     let dir = get_sqllog_dir();
     trace!("获取到 sqllog 目录: {}", dir.display());
     if !dir.exists() {
-        error!("目录不存在: {}", std::env::current_dir()?.display());
+        error!("目录不存在: {}", env::current_dir()?.display());
         return Ok(());
     }
     trace!("开始处理目录: {}", dir.display());

--- a/src/process.rs
+++ b/src/process.rs
@@ -3,9 +3,12 @@
 use crate::sqllog::Sqllog;
 use anyhow::Result;
 use log::{info, trace};
-use std::fs::OpenOptions;
-use std::io::Write;
-use std::path::Path;
+use std::{
+    fs::{self, OpenOptions},
+    io::Write,
+    path::Path,
+    time,
+};
 
 /// 扫描指定目录，解析所有 dmsql*.log 文件。
 ///
@@ -28,14 +31,14 @@ use std::path::Path;
 /// - 解析进度和耗时通过 println 输出
 pub fn process_sqllog_dir<P: AsRef<Path>>(
     dir: P,
-) -> Result<(usize, usize, Vec<(String, String)>, std::time::Duration)> {
+) -> Result<(usize, usize, Vec<(String, String)>, time::Duration)> {
     let mut total_files = 0;
     let mut total_logs = 0;
     let mut error_files = Vec::new();
-    use std::time::Instant;
+    use time::Instant;
     let global_start = Instant::now();
     // 遍历目录下所有文件
-    for entry in std::fs::read_dir(&dir)? {
+    for entry in fs::read_dir(&dir)? {
         let entry = entry?;
         let path = entry.path();
         // 跳过非文件（如文件夹）
@@ -45,7 +48,7 @@ pub fn process_sqllog_dir<P: AsRef<Path>>(
         // 仅处理 dmsql*.log 文件
         if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
             if name.starts_with("dmsql")
-                && std::path::Path::new(name)
+                && Path::new(name)
                     .extension()
                     .is_some_and(|ext| ext.eq_ignore_ascii_case("log"))
             {

--- a/tests/duckdb_index_failure.rs
+++ b/tests/duckdb_index_failure.rs
@@ -1,0 +1,44 @@
+use sqllog_analysis::duckdb_writer;
+use sqllog_analysis::sqllog::Sqllog;
+use std::env;
+use tempfile::tempdir;
+
+#[test]
+fn test_index_creation_failure_reports_error() {
+    // instruct writer to inject a bad index statement
+    unsafe {
+        env::set_var("SQLOG_INJECT_BAD_INDEX", "1");
+        env::set_var("SQLOG_CREATE_INDEXES", "1");
+    }
+
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir.path().join("test_sqllogs_bad.duckdb");
+
+    let records = vec![Sqllog {
+        occurrence_time: "2025-09-20 12:00:00.000".to_string(),
+        ep: 1,
+        session: Some("sess1".to_string()),
+        thread: Some("thr1".to_string()),
+        user: Some("u1".to_string()),
+        trx_id: Some("trx1".to_string()),
+        statement: Some("select 1".to_string()),
+        appname: Some("app".to_string()),
+        ip: Some("127.0.0.1".to_string()),
+        sql_type: Some("SEL".to_string()),
+        description: "desc".to_string(),
+        execute_time: Some(10),
+        rowcount: Some(1),
+        execute_id: Some(100),
+    }];
+
+    let reports =
+        duckdb_writer::write_sqllogs_to_duckdb_with_chunk_and_report(&db_path, &records, 1, true)
+            .expect("write should succeed");
+
+    // we expect at least one report entry to contain an error due to injection
+    let any_error = reports.iter().any(|r| r.error.is_some());
+    assert!(
+        any_error,
+        "expected at least one index creation to fail and be reported"
+    );
+}

--- a/tests/duckdb_integration.rs
+++ b/tests/duckdb_integration.rs
@@ -1,0 +1,90 @@
+use duckdb::Connection;
+use sqllog_analysis::duckdb_writer;
+use sqllog_analysis::sqllog::Sqllog;
+use std::env;
+use tempfile::tempdir;
+
+#[test]
+fn test_write_and_index_duckdb() {
+    // Ensure indexes will be created for this test
+    unsafe {
+        env::set_var("SQLOG_CREATE_INDEXES", "1");
+    }
+
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir.path().join("test_sqllogs.duckdb");
+
+    let records = vec![
+        Sqllog {
+            occurrence_time: "2025-09-20 12:00:00.000".to_string(),
+            ep: 1,
+            session: Some("sess1".to_string()),
+            thread: Some("thr1".to_string()),
+            user: Some("u1".to_string()),
+            trx_id: Some("trx1".to_string()),
+            statement: Some("select 1".to_string()),
+            appname: Some("app".to_string()),
+            ip: Some("127.0.0.1".to_string()),
+            sql_type: Some("SEL".to_string()),
+            description: "desc".to_string(),
+            execute_time: Some(10),
+            rowcount: Some(1),
+            execute_id: Some(100),
+        },
+        Sqllog {
+            occurrence_time: "2025-09-20 12:00:01.000".to_string(),
+            ep: 2,
+            session: Some("sess2".to_string()),
+            thread: Some("thr2".to_string()),
+            user: Some("u2".to_string()),
+            trx_id: Some("trx2".to_string()),
+            statement: Some("select 2".to_string()),
+            appname: Some("app".to_string()),
+            ip: Some("127.0.0.2".to_string()),
+            sql_type: Some("SEL".to_string()),
+            description: "desc2".to_string(),
+            execute_time: Some(20),
+            rowcount: Some(2),
+            execute_id: Some(200),
+        },
+    ];
+
+    // write to DB and collect index creation report
+    let reports =
+        duckdb_writer::write_sqllogs_to_duckdb_with_chunk_and_report(&db_path, &records, 1, true)
+            .expect("write should succeed");
+
+    // ensure index creation produced reports and none contain errors
+    assert!(!reports.is_empty());
+    for r in &reports {
+        assert!(
+            r.error.is_none(),
+            "index '{}' failed: {:?}",
+            r.statement,
+            r.error
+        );
+    }
+
+    // open DB and verify rows
+    let conn = Connection::open(&db_path).expect("open db");
+    let mut stmt = conn
+        .prepare("SELECT COUNT(*) FROM sqllogs")
+        .expect("prepare");
+    let count: i64 = stmt.query_row([], |row| row.get(0)).expect("query_row");
+    assert_eq!(count, 2);
+
+    // verify indexed columns exist by attempting a query that would use them
+    let mut stmt2 = conn
+        .prepare("SELECT trx_id, thread, session, ip FROM sqllogs ORDER BY execute_id")
+        .expect("prepare2");
+    let mut rows = stmt2.query([]).expect("query");
+    let mut seen = 0;
+    while let Some(r) = rows.next().expect("row next") {
+        let _trx: Option<String> = r.get(0).ok();
+        let _thr: Option<String> = r.get(1).ok();
+        let _sess: Option<String> = r.get(2).ok();
+        let _ip: Option<String> = r.get(3).ok();
+        seen += 1;
+    }
+    assert_eq!(seen, 2);
+}

--- a/tests/main_integration_tests.rs
+++ b/tests/main_integration_tests.rs
@@ -1,15 +1,20 @@
 use sqllog_analysis::process::{process_sqllog_dir, write_error_files};
-use std::fs::{self, File};
-use std::io::Write;
+use std::{
+    env,
+    fs::{self, File},
+    io::Write,
+    panic,
+    path::PathBuf,
+};
 use tempfile::tempdir;
 
 #[test]
 fn test_main_dir_not_exist() {
-    let dir = std::path::PathBuf::from("not_exist_dir_for_test");
+    let dir = PathBuf::from("not_exist_dir_for_test");
     assert!(!dir.exists());
-    let result = std::panic::catch_unwind(|| {
+    let result = panic::catch_unwind(|| {
         if !dir.exists() {
-            println!("目录不存在: {:?}", std::env::current_dir().unwrap());
+            println!("目录不存在: {:?}", env::current_dir().unwrap());
         }
     });
     assert!(result.is_ok());
@@ -27,14 +32,14 @@ fn test_main_with_error_files() {
     assert!(!error_files.is_empty());
     let result = write_error_files(&error_files);
     assert!(result.is_ok());
-    let content = std::fs::read_to_string("error_files.txt").unwrap();
+    let content = fs::read_to_string("error_files.txt").unwrap();
     assert!(content.contains("dmsql_test.log"));
 }
 
 #[test]
 fn test_main_no_log_files() {
     let dir = tempdir().unwrap();
-    let result = std::panic::catch_unwind(|| {
+    let result = panic::catch_unwind(|| {
         for entry in fs::read_dir(dir.path()).unwrap() {
             let path = entry.unwrap().path();
             if path.is_file() {

--- a/tests/main_tests.rs
+++ b/tests/main_tests.rs
@@ -1,8 +1,11 @@
 #![allow(clippy::uninlined_format_args)]
 #![allow(clippy::let_unit_value)]
 use sqllog_analysis::sqllog::Sqllog;
-use std::fs::{self, File};
-use std::io::Write;
+use std::{
+    fs::{self, File},
+    io::Write,
+    panic,
+};
 use tempfile::tempdir;
 
 #[test]
@@ -10,7 +13,7 @@ fn test_main_dir_not_exist() {
     let tmp = tempdir().unwrap();
     let dir = tmp.path().join("not_exist_dir");
     assert!(!dir.exists());
-    let result = std::panic::catch_unwind(|| {
+    let result = panic::catch_unwind(|| {
         let _ = {
             let sqllog_dir = &dir;
             if !sqllog_dir.exists() {
@@ -27,7 +30,7 @@ fn test_main_no_log_files() {
     let tmp = tempdir().unwrap();
     let dir = tmp.path();
     fs::create_dir_all(dir).unwrap();
-    let result = std::panic::catch_unwind(|| {
+    let result = panic::catch_unwind(|| {
         let sqllog_dir = dir;
         println!("正在检查 sqllog 目录下的 dmsql*.log 文件...");
         for entry in fs::read_dir(sqllog_dir).unwrap() {
@@ -52,7 +55,7 @@ fn test_main_parse_success_and_error() {
     let mut file = File::create(&file_path).unwrap();
     writeln!(file, "2025-10-10 10:10:10.100 (EP[1] sess:0x1234 thrd:1234 user:SYSDBA trxid:5678 stmt:0xabcd) [SEL]: SELECT").unwrap();
     writeln!(file, "invalid line").unwrap();
-    let result = std::panic::catch_unwind(|| {
+    let result = panic::catch_unwind(|| {
         let sqllog_dir = dir;
         for entry in fs::read_dir(sqllog_dir).unwrap() {
             let path = entry.unwrap().path();


### PR DESCRIPTION
# Summary

This PR adds IndexReport (per-index timing + error reporting) and changes index creation to run in independent short transactions so we can capture failures per-index. It also adds two integration tests: a success path and an injected-failure path that uses `SQLOG_INJECT_BAD_INDEX`. README is updated with usage and CI examples.

# Changes
- src/duckdb_writer.rs: Add `IndexReport`, transactional per-index CREATE INDEX, `SQLOG_INDEX_LOG_LEVEL` and `SQLOG_INJECT_BAD_INDEX` test hook.
- tests/duckdb_integration.rs: Integration test verifying inserts and index usage.
- tests/duckdb_index_failure.rs: Integration test that sets `SQLOG_INJECT_BAD_INDEX=1` and asserts failure is reported in `IndexReport`.
- README.md: Documentation and CI examples.

# Validation
- `cargo test`: all tests passed locally (including injected failure test).
- `cargo clippy` with strict flags: completed; no blocking warnings.

# How to run locally
- Run all tests:
```powershell
cargo test --all
```
- Run only the injected-index failure test:
```powershell
$env:SQLOG_INJECT_BAD_INDEX = "1"; $env:SQLOG_CREATE_INDEXES = "1"; cargo test --test duckdb_index_failure
```

# Notes / Compatibility
- Index creation is run after bulk insert; each index is created in its own transaction. A failing index will be reported in `IndexReport` and doesn't abort the creation of other indexes.
- If you want atomic index creation (all-or-nothing), change the implementation to create all indexes within a single transaction; tradeoff: rollback on any failure.

# Test & clippy outputs
- Tests: all passed locally (full suite).
- Clippy: ran with strict flags; no blocking warnings.
